### PR TITLE
Add login redirect page

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function LoginPage() {
+  redirect("https://planificador-muvitrans.vercel.app");
+}


### PR DESCRIPTION
## Summary
- add Next.js login page that redirects users to the external planner application

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5fe7b4f8832cbc1fcf19901fa0c9